### PR TITLE
php5enmod support

### DIFF
--- a/suhosin.ini
+++ b/suhosin.ini
@@ -1,3 +1,4 @@
+; priority=00
 
 ;extension=suhosin.so
 


### PR DESCRIPTION
Please consider supporting `php5enmod` - a php5 module manager for Debian.
It read the symlink's priority from the config.
For example: `/etc/php5/fpm/conf.d/00-suhosin.ini`
