### PR TITLE
use different HTTP headers other than X-Forwarded-For

### DIFF
--- a/log.c
+++ b/log.c
@@ -130,18 +130,22 @@ PHP_SUHOSIN_API void suhosin_log(int loglevel, char *fmt, ...)
 		volatile int y = *x;
 	}
 	
+	char*	remote_addr_hdr;
+
 	if (SUHOSIN_G(log_use_x_forwarded_for)) {
-		ip_address = suhosin_getenv("HTTP_X_FORWARDED_FOR", 20 TSRMLS_CC);
-		if (ip_address == NULL) {
-			ip_address = "X-FORWARDED-FOR not set";
-		}
+		remote_addr_hdr = SUHOSIN_G(log_remote_addr_header);
 	} else {
-		ip_address = suhosin_getenv("REMOTE_ADDR", 11 TSRMLS_CC);
-		if (ip_address == NULL) {
-			ip_address = "REMOTE_ADDR not set";
-		}
+		remote_addr_hdr = "REMOTE_ADDR";
 	}
-	
+
+	ip_address = suhosin_getenv(remote_addr_hdr, strlen(remote_addr_hdr) TSRMLS_CC);
+
+	char	ip_address_string[5000];
+
+	if (ip_address == NULL ) {
+		ip_address = ip_address_string;
+		ap_php_snprintf(ip_address_string, sizeof(ip_address_string), "%s not set", remote_addr_hdr);
+	}
 	
 	va_start(ap, fmt);
 	ap_php_vsnprintf(error, sizeof(error), fmt, ap);

--- a/php_suhosin.h
+++ b/php_suhosin.h
@@ -223,6 +223,7 @@ ZEND_BEGIN_MODULE_GLOBALS(suhosin)
 
 /*	log */
 	zend_bool log_use_x_forwarded_for;
+	char	*log_remote_addr_header;
 	long	log_syslog;
 	long	log_syslog_facility;
 	long	log_syslog_priority;

--- a/suhosin.c
+++ b/suhosin.c
@@ -778,6 +778,7 @@ static zend_ini_entry shared_ini_entries[] = {
 	ZEND_INI_ENTRY("suhosin.log.script",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_script)
 	ZEND_INI_ENTRY("suhosin.log.script.name",			NULL,		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_scriptname)
 	STD_ZEND_INI_BOOLEAN("suhosin.log.use-x-forwarded-for",	"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateLogBool, log_use_x_forwarded_for,	zend_suhosin_globals,	suhosin_globals)
+	STD_ZEND_INI_ENTRY("suhosin.log.remote-addr-header",		"HTTP_X_FORWARDED_FOR",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateLogString, log_remote_addr_header,	zend_suhosin_globals,	suhosin_globals)
 	ZEND_INI_ENTRY("suhosin.log.phpscript",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_phpscript)
 	STD_ZEND_INI_ENTRY("suhosin.log.phpscript.name",			NULL,		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateLogString, log_phpscriptname, zend_suhosin_globals, suhosin_globals)
 	ZEND_INI_ENTRY("suhosin.log.file",			"0",		ZEND_INI_PERDIR|ZEND_INI_SYSTEM,	OnUpdateSuhosin_log_file)

--- a/suhosin.ini
+++ b/suhosin.ini
@@ -296,6 +296,19 @@
 ;suhosin.log.use-x-forwarded-for = Off
 ;
 
+; suhosin.log.remote-addr-header
+; -------------------------------
+; * Type: String
+; * Default: HTTP_X_FORWARDED_FOR
+; 
+; If suhosin.log.use-x-forwarded-for is enabled this parameter allows to
+; specify environment variable is used to read the IP address. This is for 
+; example necessary when your PHP server runs behind a reverse proxy and the
+; proxy uses a HTTP header other than X-Forwarded-For.
+; 
+;suhosin.log.remote-addr-header = "HTTP_X_FORWARDED_FOR"
+;
+
 ; ================
 ; Executor Options
 ; ================

--- a/tests/logging/use_remote_addr_header.phpt
+++ b/tests/logging/use_remote_addr_header.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Testing: suhosin.log.remote-addr-header=HTTP_X_REMOTE_CLIENT_IP
+--SKIPIF--
+<?php include "../skipifnotcli.inc"; ?>
+--INI--
+suhosin.log.syslog=0
+suhosin.log.sapi=0
+suhosin.log.script=0
+suhosin.log.file=255
+suhosin.log.file.time=0
+suhosin.log.file.name={PWD}/suhosintest.$$.log.tmp
+auto_append_file={PWD}/suhosintest.$$.log.tmp
+suhosin.executor.func.blacklist=max
+suhosin.log.use-x-forwarded-for=On
+suhosin.log.remote-addr-header=HTTP_X_REMOTE_CLIENT_IP
+suhosin.simulation=1
+--ENV--
+return <<<END
+REMOTE_ADDR=101.102.103.104
+HTTP_X_REMOTE_CLIENT_IP=5.6.7.8
+END;
+--FILE--
+<?php
+	max(1,2);
+?>
+--EXPECTF--
+Warning: SIMULATION - max() has been disabled for security reasons in %s on line 2
+ALERT-SIMULATION - function within blacklist called: max() (attacker '5.6.7.8', file '%s', line 2)

--- a/tests/logging/use_remote_addr_header_missing.phpt
+++ b/tests/logging/use_remote_addr_header_missing.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Testing: suhosin.log.remote-addr-header=HTTP_X_REMOTE_CLIENT_IP but missing
+--SKIPIF--
+<?php include "../skipifnotcli.inc"; ?>
+--INI--
+suhosin.log.syslog=0
+suhosin.log.sapi=0
+suhosin.log.script=0
+suhosin.log.file=255
+suhosin.log.file.time=0
+suhosin.log.file.name={PWD}/suhosintest.$$.log.tmp
+auto_append_file={PWD}/suhosintest.$$.log.tmp
+suhosin.executor.func.blacklist=max
+suhosin.log.use-x-forwarded-for=On
+suhosin.log.remote-addr-header=HTTP_X_REMOTE_CLIENT_IP
+suhosin.simulation=1
+--ENV--
+return <<<END
+REMOTE_ADDR=101.102.103.104
+HTTP_X_FORWARDED_FOR=1.2.3.4
+END;
+--FILE--
+<?php
+	max(1,2);
+?>
+--EXPECTF--
+Warning: SIMULATION - max() has been disabled for security reasons in %s on line 2
+ALERT-SIMULATION - function within blacklist called: max() (attacker 'HTTP_X_REMOTE_CLIENT_IP not set', file '%s', line 2)


### PR DESCRIPTION
Dear all,

our web server is behind a proxy cascade. So the X-Forwarded-For header only delivers the ip address of the front end proxy but the ip address is in a different header (for example X-Remote-Client-IP). Changing the names is not possible for technical reasons outside my influence.

To deal with this I integrated a new option suhosin.log.remote-addr-header (with "HTTP_X_FORWARDED_FOR" as default). This option is only used if suhosin.log.remote-addr-header is enabled.

I decided to use the php style to reference headers. So you have to prepend HTTP_ and translate hyphens to underscores.

I also integrated a documented entry in the suhosin.ini and added some test scripts.


with kind regards,
Joerg